### PR TITLE
Change has to exists

### DIFF
--- a/src/Updaters/UpdateTranslations.php
+++ b/src/Updaters/UpdateTranslations.php
@@ -13,7 +13,7 @@ trait UpdateTranslations
             foreach ($model->getTranslatableAttributes() as $fieldName) {
                 $translatedFieldName = translate_field_name($fieldName, $locale);
 
-                if (! $request->has($translatedFieldName)) {
+                if (! $request->exists($translatedFieldName)) {
                     continue;
                 }
 


### PR DESCRIPTION
It wasn't possible to update a translated field value to an empty string. Because the `has` method returns false if the value is empty. This should be handled by the (form request) validation.